### PR TITLE
Add sh1, sh2 support to sogs

### DIFF
--- a/src/pcsogs.ts
+++ b/src/pcsogs.ts
@@ -97,9 +97,18 @@ export async function unpackPcSogs(
   }
 
   if (json.shN) {
-    extra.sh1 = new Uint32Array(numSplats * 2);
-    extra.sh2 = new Uint32Array(numSplats * 4);
-    extra.sh3 = new Uint32Array(numSplats * 4);
+
+    const useSH3 = json.shN.shape[1] >= 48 - 3;
+    const useSH2 = json.shN.shape[1] >= 27 - 3;
+    const useSH1 = json.shN.shape[1] >= 12 - 3;
+
+    if(useSH1)
+      extra.sh1 = new Uint32Array(numSplats * 2);
+    if(useSH2)
+      extra.sh2 = new Uint32Array(numSplats * 4);
+    if(useSH3)
+      extra.sh3 = new Uint32Array(numSplats * 4);
+
     const sh1 = new Float32Array(9);
     const sh2 = new Float32Array(15);
     const sh3 = new Float32Array(21);
@@ -116,32 +125,45 @@ export async function unpackPcSogs(
       const offset = row * centroids.width + col;
 
       for (let d = 0; d < 3; ++d) {
-        for (let k = 0; k < 3; ++k) {
-          sh1[k * 3 + d] =
+        
+        if(useSH1) {
+          for (let k = 0; k < 3; ++k) {
+            sh1[k * 3 + d] =
             json.shN.mins +
             ((json.shN.maxs - json.shN.mins) *
               centroids.rgba[(offset + k) * 4 + d]) /
               255;
+          }
         }
-        for (let k = 0; k < 5; ++k) {
-          sh2[k * 3 + d] =
+
+        if(useSH2) {
+          for (let k = 0; k < 5; ++k) {
+            sh2[k * 3 + d] =
             json.shN.mins +
             ((json.shN.maxs - json.shN.mins) *
               centroids.rgba[(offset + 3 + k) * 4 + d]) /
               255;
+          }
         }
-        for (let k = 0; k < 7; ++k) {
-          sh3[k * 3 + d] =
+
+        if(useSH3) {
+          for (let k = 0; k < 7; ++k) {
+            sh3[k * 3 + d] =
             json.shN.mins +
             ((json.shN.maxs - json.shN.mins) *
               centroids.rgba[(offset + 8 + k) * 4 + d]) /
               255;
+          }
         }
       }
 
-      encodeSh1Rgb(extra.sh1 as Uint32Array, i, sh1);
-      encodeSh2Rgb(extra.sh2 as Uint32Array, i, sh2);
-      encodeSh3Rgb(extra.sh3 as Uint32Array, i, sh3);
+      if(useSH1)
+        encodeSh1Rgb(extra.sh1 as Uint32Array, i, sh1);
+      if(useSH2)
+        encodeSh2Rgb(extra.sh2 as Uint32Array, i, sh2);
+      if(useSH3)
+        encodeSh3Rgb(extra.sh3 as Uint32Array, i, sh3);
+    
     }
   }
 


### PR DESCRIPTION
pcsogs loader was assuming sh3, so this supports sh1, sh2 modes too.